### PR TITLE
Potentially make axe-webdriver less fragile

### DIFF
--- a/lib/axe-stats.js
+++ b/lib/axe-stats.js
@@ -33,7 +33,21 @@ function getAxeStats(
     const axe = AxeBuilder(driver);
 
     return new Promise((resolve, reject) => {
+      const UNCAUGHT = 'uncaughtException';
+
+      function uncaughtHandler(err) {
+        process.removeListener(UNCAUGHT, uncaughtHandler);
+        if (err && /axe is not defined/.test(err.toString())) {
+          reject(err);
+        } else {
+          throw err;
+        }
+      }
+
+      process.on(UNCAUGHT, uncaughtHandler);
+
       axe.analyze(results => {
+        process.removeListener(UNCAUGHT, uncaughtHandler);
         resolve(results);
       });
     });


### PR DESCRIPTION
This is a most-likely-horrible attempt to make axe-webdriver less fragile, as documented in #17.