### PR TITLE
Show axe violations in <details>

### DIFF
--- a/lib/components/table.jsx
+++ b/lib/components/table.jsx
@@ -34,6 +34,24 @@ export type Record = {
 };
 */
 
+function AxeViolationsCell(props /*: { violations: Array<BasicAxeViolation> } */) {
+  if (props.violations.length === 0) {
+    return <span>{props.violations.length}</span>;
+  }
+  return (
+    <details>
+      <summary>{props.violations.length}</summary>
+      <ul>
+        {props.violations.map(v => (
+          <li key={v.kind}>
+            {v.kind} ({v.nodeCount} {v.nodeCount === 1 ? 'node' : 'nodes'})
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+
 class Row extends React.Component {
   /*::
   props: {
@@ -50,16 +68,15 @@ class Row extends React.Component {
     const repoUrl = `https://github.com/${repo}`;
     const q = encodeURIComponent(QUERY);
     const issuesUrl = `https://github.com/${repo}/search?q=${q}&type=Issues`;
-    const violationTip = this.props.axeStats.violations.map(v => (
-      v.nodeCount === 1 ? v.kind : `${v.kind} (${v.nodeCount} nodes)`
-    )).join(', ');
 
     return (
       <tr>
         <td><a href={homepage}>{shortHomepage}</a></td>
         <td><a href={repoUrl}>{repo}</a></td>
         <td><a href={issuesUrl}>{this.props.issueCount}</a></td>
-        <td title={violationTip}>{this.props.axeStats.violations.length}</td>
+        <td className="axe-violations">
+          <AxeViolationsCell violations={this.props.axeStats.violations}/>
+        </td>
         <td>{this.props.axeStats.passes}</td>
       </tr>
     );

--- a/lib/components/table.jsx
+++ b/lib/components/table.jsx
@@ -44,7 +44,8 @@ function AxeViolationsCell(props /*: { violations: Array<BasicAxeViolation> } */
       <ul>
         {props.violations.map(v => (
           <li key={v.kind}>
-            {v.kind} ({v.nodeCount} {v.nodeCount === 1 ? 'node' : 'nodes'})
+            {v.kind}
+            {v.nodeCount > 1 ? <aside>{v.nodeCount} elements</aside> : null}
           </li>
         ))}
       </ul>

--- a/static/style.css
+++ b/static/style.css
@@ -1,5 +1,29 @@
 @import url(./vendor/uswds/css/uswds.min.css);
 
+details summary::-webkit-details-marker {
+  display: none;
+}
+
+details ul {
+  font-size: 1rem;
+}
+
+summary:after {
+  float: right;
+  font-family: monospace;
+  content: "+";
+  cursor: pointer;
+  color: #0071bc;
+}
+
+details[open] summary:after {
+  content: "-";
+}
+
+td.axe-violations {
+  width: 10em;
+}
+
 html {
   padding: 0 2em;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -6,6 +6,7 @@ details summary::-webkit-details-marker {
 
 details ul {
   font-size: 1rem;
+  margin-bottom: 0;
 }
 
 summary:after {
@@ -22,6 +23,10 @@ details[open] summary:after {
 
 td.axe-violations {
   width: 10em;
+}
+
+td.axe-violations aside {
+  color: crimson;
 }
 
 html {


### PR DESCRIPTION
This shows aXe violations in a collapsible `<details>` element, so that users can click on the cell to see an expanded list of all aXe violations for a homepage:

> ![2017-04-17_17-30-31](https://cloud.githubusercontent.com/assets/124687/25105664/98620c0e-2393-11e7-9396-48da6d63cc0a.png)

If the number of elements violating an aXe rule is greater than one, the number is displayed in red.

If there are no aXe violations for a site, the number "0" is displayed in the cell without any `<details>` element, since there's no information to expand/collapse.

When a cell is collapsed, a "+" is displayed on its right side; when expanded, a "-" is displayed.